### PR TITLE
Change from FTP to HTTP site

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: ftp://ftp.iag.usp.br/pub/gmt/{{ name }}-{{ version }}.tar.gz
+  url: https://generic-mapping-tools.iag.usp.br/gmt/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
Point to https://generic-mapping-tools.iag.usp.br/gmt/gshhg-gmt-2.3.7.tar.gz instead of ftp://ftp.iag.usp.br/pub/gmt/gshhg-gmt-2.3.7.tar.gz. See also https://github.com/GenericMappingTools/gshhg-gmt and https://www.generic-mapping-tools.org/mirrors/index.html. Fixes timeout issue on https://github.com/conda-forge/gshhg-gmt-feedstock/pull/5.

Note: Will probably need to add `[ci skip] [skip ci] [cf admin skip] ***NO_CI***` to the commit title when merging this PR.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
